### PR TITLE
Reduce package/module bloat considerably with some tiny changes

### DIFF
--- a/build/unicode-length.js
+++ b/build/unicode-length.js
@@ -1,10 +1,8 @@
-var REGEX_SYMBOLS, punycode, stripAnsi, _;
+var REGEX_SYMBOLS, punycode, stripAnsi;
 
 punycode = require('punycode');
 
 stripAnsi = require('strip-ansi');
-
-_ = require('lodash');
 
 REGEX_SYMBOLS = /([\0-\u02FF\u0370-\u1DBF\u1E00-\u20CF\u2100-\uD7FF\uDC00-\uFE1F\uFE30-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF])([\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]+)/g;
 
@@ -13,7 +11,7 @@ exports.get = function(input) {
   if (input == null) {
     throw new Error('Missing input');
   }
-  if (!_.isString(input)) {
+  if (typeof input !== 'string') {
     throw new Error("Invalid input: " + input);
   }
   input = stripAnsi(input);

--- a/build/unicode-length.js
+++ b/build/unicode-length.js
@@ -1,8 +1,8 @@
-var REGEX_SYMBOLS, chalk, punycode, _;
+var REGEX_SYMBOLS, punycode, stripAnsi, _;
 
 punycode = require('punycode');
 
-chalk = require('chalk');
+stripAnsi = require('strip-ansi');
 
 _ = require('lodash');
 
@@ -16,7 +16,7 @@ exports.get = function(input) {
   if (!_.isString(input)) {
     throw new Error("Invalid input: " + input);
   }
-  input = chalk.stripColor(input);
+  input = stripAnsi(input);
   stripped = input.replace(REGEX_SYMBOLS, function($0, symbol, combiningMarks) {
     return symbol;
   });

--- a/lib/unicode-length.coffee
+++ b/lib/unicode-length.coffee
@@ -1,6 +1,5 @@
 punycode = require('punycode')
 stripAnsi = require('strip-ansi')
-_ = require('lodash')
 
 # From https://github.com/mathiasbynens/esrever/blob/master/scripts/export-data.js
 
@@ -11,7 +10,7 @@ exports.get = (input) ->
 	if not input?
 		throw new Error('Missing input')
 
-	if not _.isString(input)
+	if typeof input != 'string'
 		throw new Error("Invalid input: #{input}")
 
 	# Also strip colour escape sequences

--- a/lib/unicode-length.coffee
+++ b/lib/unicode-length.coffee
@@ -1,5 +1,5 @@
 punycode = require('punycode')
-chalk = require('chalk')
+stripAnsi = require('strip-ansi')
 _ = require('lodash')
 
 # From https://github.com/mathiasbynens/esrever/blob/master/scripts/export-data.js
@@ -15,7 +15,7 @@ exports.get = (input) ->
 		throw new Error("Invalid input: #{input}")
 
 	# Also strip colour escape sequences
-	input = chalk.stripColor(input)
+	input = stripAnsi(input)
 
 	# Remove any combining marks, leaving only the symbols they belong to:
 	stripped = input.replace REGEX_SYMBOLS, ($0, symbol, combiningMarks) ->

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
     "lodash": "^3.7.0",
-    "punycode": "^1.3.2"
+    "punycode": "^1.3.2",
+    "strip-ansi": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Get the length of unicode strings",
   "main": "build/unicode-length.js",
+  "files": [
+    "build/unicode-length.js"
+  ],
   "homepage": "https://github.com/jviotti/unicode-length",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
-    "lodash": "^3.7.0",
     "punycode": "^1.3.2",
     "strip-ansi": "^3.0.1"
   }


### PR DESCRIPTION
1. Replace `chalk` with `strip-ansi`, since most of chalk is unnecessary here.  (In fact, `chalk.stripColor` is just a link to `stripAnsi` anyway :)
2. Replace `lodash.isString` with a simple `typeof input != 'string'` check.  No need for all of lodash's stuff.
3. Don't ship tests or coffeescript in the package.  Keep the file size down by specifying the `files` array with just the result of the coffee script build.

Should be no change in the behavior, so a patch release would be appropriate.  One could argue that previously a `new String(input)` would've worked, and that now it won't, so that could be considered a breaking change.  It could be mitigated by doing `typeof input == 'string' || input instanceof String` easily enough, if that's a concern.  (In practice, I've found that I usually never encounter `String` objects, and always encounter plain old simple `string` types.)