### PR TITLE
Upgrade punycode to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
-    "punycode": "^1.3.2",
+    "punycode": "^2.0.0",
     "strip-ansi": "^3.0.1"
   }
 }


### PR DESCRIPTION
Previous version was causing problems on Fedora for some of our users.

The new `punycode` version doesn't introduce any breaking change that
seem to affect us. The only function we use, `punycode.usc2.decode`
remained stable.

Fixes: https://github.com/jviotti/unicode-length/issues/2
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>