### PR TITLE
Revert "Upgrade punycode to v2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
-    "punycode": "^2.0.0",
+    "punycode": "^1.3.2",
     "strip-ansi": "^3.0.1"
   }
 }


### PR DESCRIPTION
This reverts commit 268fc34e16b1a1af7f3e9034f26f374a363cf4fa.

The new punycode version is incompatible with NodeJS versions before
v6.0.0.

As a solution, we revert the upgrade, release a patch version, then
upgrade again, and release a major version to correctly signal the
breaking changes using semver.

See: https://github.com/jviotti/unicode-length/commit/268fc34e16b1a1af7f3e9034f26f374a363cf4fa#commitcomment-18755250